### PR TITLE
Use a factory function instead of a constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Examples:
 
 ```js
 const yargs = require('yargs');
-const YargsPromise = require('yargs-promise');
+const yargsPromise = require('yargs-promise');
 
 // create the customized yargs parser
-const parser = new YargsPromise(yargs);
+const parser = yargsPromise(yargs);
 
 // setup command & command handler
 parser
@@ -59,9 +59,9 @@ Customizing context example
 
 ```js
 const yargs = require('yargs');
-const YargsPromise = require('yargs-promise');
+const yargsPromise = require('yargs-promise');
 
-const parser = new YargsPromise(
+const parser = yargsPromise(
   yargs,
   // customize context
   {

--- a/index.js
+++ b/index.js
@@ -1,48 +1,5 @@
-class YargsPromise {
-  constructor(yargs, ctx) {
-    this.ctx = ctx || {};
-    this.yargs = yargs;
-    this.parse = this.parse.bind(this);
-    this.command = this.yargs.command;
-    this.commandDir = this.yargs.commandDir;
-  }
+const YargsPromise = require('./yargs-promise')
 
-  parse(msg) {
-    const yargs = this.yargs;
-    let returnArgs;
-    return new Promise((resolve, reject) => {
-      let context = Object.assign({}, this.ctx, {resolve, reject});
-
-      yargs.parse(msg, context, function(error, argv, output) {
-        returnArgs = argv;
-        // the reject/resolve calls below are from
-        // internal yarg behavior.
-        if (error) {
-          // reject built in validation error
-          return argv.reject(error);
-        }
-        // resolve built in output
-        return argv.resolve(output);
-      });
-    })
-      .then(p => Promise.resolve(p)) // resolve possible promise
-      .then(data => {
-        if (data && data.argv) {
-          return data;
-        }
-
-        return {data, argv: returnArgs};
-      })
-      .catch((p) => // resolve possible promise
-        Promise.resolve(p).then(error => {
-          if (error && error.argv) {
-            return Promise.reject(error);
-          }
-
-          return Promise.reject({error, argv: returnArgs});
-        })
-      );
-  }
+module.exports = function yargsPromise (yargs, ctx) {
+  return new YargsPromise(yargs, ctx)
 }
-
-module.exports = YargsPromise;

--- a/index.test.js
+++ b/index.test.js
@@ -1,5 +1,5 @@
 const yargs = require('yargs');
-const YargsPromise = require('./index');
+const yargsPromise = require('./index');
 
 describe('YargsPromise', () => {
   let parser;
@@ -7,7 +7,7 @@ describe('YargsPromise', () => {
 
   beforeEach(() => {
     customContextMethod = jest.fn();
-    parser = new YargsPromise(yargs, {customContextMethod, foo: 'bar'});
+    parser = yargsPromise(yargs, {customContextMethod, foo: 'bar'});
   });
 
   afterEach(() => {

--- a/yargs-promise.js
+++ b/yargs-promise.js
@@ -1,0 +1,48 @@
+class YargsPromise {
+  constructor(yargs, ctx) {
+    this.ctx = ctx || {};
+    this.yargs = yargs;
+    this.parse = this.parse.bind(this);
+    this.command = this.yargs.command;
+    this.commandDir = this.yargs.commandDir;
+  }
+
+  parse(msg) {
+    const yargs = this.yargs;
+    let returnArgs;
+    return new Promise((resolve, reject) => {
+      let context = Object.assign({}, this.ctx, {resolve, reject});
+
+      yargs.parse(msg, context, function(error, argv, output) {
+        returnArgs = argv;
+        // the reject/resolve calls below are from
+        // internal yarg behavior.
+        if (error) {
+          // reject built in validation error
+          return argv.reject(error);
+        }
+        // resolve built in output
+        return argv.resolve(output);
+      });
+    })
+      .then(p => Promise.resolve(p)) // resolve possible promise
+      .then(data => {
+        if (data && data.argv) {
+          return data;
+        }
+
+        return {data, argv: returnArgs};
+      })
+      .catch((p) => // resolve possible promise
+        Promise.resolve(p).then(error => {
+          if (error && error.argv) {
+            return Promise.reject(error);
+          }
+
+          return Promise.reject({error, argv: returnArgs});
+        })
+      );
+  }
+}
+
+module.exports = YargsPromise;


### PR DESCRIPTION
This PR changes the primary API exposed by this package from using a constructor, to using a factory function. Tests and documentation changes included.

It would be a BC break, but this change has a couple of primary benefits:

1. Usage of this library gets simpler.
2. If you decide to refactor the internals later, you're not bound to using specific arguments in your constructor.

In my use case, the usage changes from this:

```js
import yargs from 'yargs'
import YargsPromise from 'yargs-promise'

const yargsPromise = new YargsPromise(yargs)

yargsPromise
  .commandDir('command')
  .demandCommand()
  .help()
  .argv
```

to this:

```js
import yargs from 'yargs'
import yargsPromise from 'yargs-promise'

yargsPromise(yargs)
  .commandDir('command')
  .demandCommand()
  .help()
  .argv
```

Which, at least IMO, is a bit nicer/cleaner.